### PR TITLE
Improve cheater report classification with new trust tiers and account signals

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -64,7 +64,17 @@
     "innocentDescription": "This player shows normal/standard profile signs:",
     "isUserCheaterCS2": "Is {nickname} a cheater in CS2?",
     "normalKD": "Normal K/D ratio ({kd})",
-    "highKD": "High K/D ratio ({kd}, unusually strong performance)"
+    "highKD": "High K/D ratio ({kd}, unusually strong performance)",
+    "veryTrustedTitle": "Very Trusted Profile",
+    "veryTrustedDescription": "This profile shows exceptional signs of legitimacy and investment:",
+    "highlySuspectTitle": "Highly Suspect!",
+    "highlySuspectDescription": "Critical warning: Multiple high-risk factors detected:",
+    "oldAccount": "Veteran account ({age} years old)",
+    "newAccount": "Recent account ({age} years old, common for smurfs/cheaters)",
+    "highSteamLevel": "High Steam level (Level {level}, sign of investment)",
+    "lowSteamLevel": "Low Steam level (Level {level}, typical of disposable accounts)",
+    "manyGames": "Large library ({count} games owned)",
+    "fewGames": "Small library ({count} games, possible secondary account)"
   },
   "SupportedFormatsSection": {
     "steamID64Desc": "Unique 64-bit Steam ID.",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -64,7 +64,17 @@
     "innocentDescription": "Este jogador apresenta sinais de perfil normal/no padrão:",
     "isUserCheaterCS2": "{nickname} é um cheater no CS2?",
     "normalKD": "K/D normal ({kd})",
-    "highKD": "K/D muito alto ({kd}, desempenho acima do padrão)"
+    "highKD": "K/D muito alto ({kd}, desempenho acima do padrão)",
+    "veryTrustedTitle": "Perfil Muito Confiável",
+    "veryTrustedDescription": "Este perfil apresenta sinais excepcionais de legitimidade e investimento:",
+    "highlySuspectTitle": "Altamente Suspeito!",
+    "highlySuspectDescription": "Aviso crítico: Múltiplos fatores de alto risco detectados:",
+    "oldAccount": "Conta veterana ({age} anos de idade)",
+    "newAccount": "Conta recente ({age} anos de idade, comum em smurfs/cheaters)",
+    "highSteamLevel": "Nível Steam alto (Nível {level}, sinal de investimento)",
+    "lowSteamLevel": "Nível Steam baixo (Nível {level}, típico de contas descartáveis)",
+    "manyGames": "Biblioteca extensa ({count} jogos na conta)",
+    "fewGames": "Biblioteca pequena ({count} jogos, possível conta secundária)"
   },
   "SupportedFormatsSection": {
     "steamID64Desc": "ID Steam único de 64 bits.",

--- a/src/@types/cheaterDataType.ts
+++ b/src/@types/cheaterDataType.ts
@@ -21,6 +21,9 @@ export type FeatureObjectType = {
   csStats: CsStats;
   analyzedFriendsCount: number;
   bannedFriendsDetails?: BannedFriendDetail[];
+  accountAge?: number;
+  totalGamesCount?: number;
+  serviceMedalsCount?: number;
 };
 
 export type CheaterDataType = {

--- a/src/@types/cheaterReportTypes.ts
+++ b/src/@types/cheaterReportTypes.ts
@@ -1,13 +1,17 @@
 export const ReportOutcomes = {
-  SUSPECT: 'suspect',
-  INCONCLUSIVE: 'inconclusive',
+  VERY_TRUSTED: 'veryTrusted',
   INNOCENT: 'innocent',
+  INCONCLUSIVE: 'inconclusive',
+  SUSPECT: 'suspect',
+  HIGHLY_SUSPECT: 'highlySuspect',
 } as const;
 
 export const StatusColors = {
-  RED: 'red',
-  YELLOW: 'yellow',
+  DARK_GREEN: 'dark-green',
   GREEN: 'green',
+  YELLOW: 'yellow',
+  ORANGE: 'orange',
+  RED: 'red',
 } as const;
 
 export type StatusColorKey = (typeof StatusColors)[keyof typeof StatusColors];

--- a/src/app/api/getCheaterProbability/route.ts
+++ b/src/app/api/getCheaterProbability/route.ts
@@ -1,13 +1,13 @@
 import { NextResponse } from 'next/server';
 import axios from 'axios';
-import SteamAPI from 'steamapi';
+import SteamAPI, { UserSummary } from 'steamapi';
 import getSteamApiKey from '@/lib/getSteamApiKey';
 import getBadCommentsScore from './utils/badCommentsMethod';
 import getBannedFriendsScore from './utils/bannedFriendsMethod';
 import getInventoryScore from './utils/inventoryMethod';
 import getPlayTimeScore from './utils/playTimeMethod';
 import getCsStats from './utils/csStats';
-import clearStat from './utils/clearCsStats';
+import { clearStat, getAccountAge } from './utils/utils';
 
 export const revalidate = 0;
 const steam = new SteamAPI(getSteamApiKey() ?? '');
@@ -46,6 +46,8 @@ export async function POST(req: Request) {
       playTimeScore,
       userLevel,
       csStats,
+      userSummary,
+      ownedGames,
     ] = await Promise.all([
       getBadCommentsScore(targetSteamId),
       getBannedFriendsScore(closeFriends),
@@ -53,10 +55,16 @@ export async function POST(req: Request) {
       getPlayTimeScore(targetSteamId),
       steam.getUserLevel(targetSteamId),
       getCsStats(targetSteamId),
+      steam.getUserSummary(targetSteamId),
+      steam.getUserOwnedGames(targetSteamId),
     ]);
 
     const { score: bannedFriendsScore, bannedFriendsDetails } =
       bannedFriendsResult;
+
+    const accountAge = getAccountAge(userSummary as UserSummary);
+
+    const totalGamesCount = Array.isArray(ownedGames) ? ownedGames.length : 0;
 
     const csStatsFeaturesArr = csStats
       ? Object.values(csStats).map(clearStat)
@@ -80,6 +88,8 @@ export async function POST(req: Request) {
       csStats,
       analyzedFriendsCount: closeFriends.length,
       bannedFriendsDetails,
+      accountAge,
+      totalGamesCount,
     };
 
     const flaskResponse = await axios.post(

--- a/src/app/api/getCheaterProbability/utils/clearCsStats.ts
+++ b/src/app/api/getCheaterProbability/utils/clearCsStats.ts
@@ -1,7 +1,0 @@
-const clearStat = (stat: string) => {
-  const cleaned = stat.replace('ms', '').replace('%', '').trim();
-
-  return cleaned === '' ? undefined : cleaned;
-};
-
-export default clearStat;

--- a/src/app/api/getCheaterProbability/utils/playTimeMethod/index.ts
+++ b/src/app/api/getCheaterProbability/utils/playTimeMethod/index.ts
@@ -17,8 +17,8 @@ const getPlayTimeScore = async (target: string) => {
     // Look for the CS2 game object in the array
     const cs2Game = allGamesArr.find((gameObj) => gameObj.game.id === CS2_ID);
 
-    // Return the playtime in minutes or 0 if CS2 is not found
-    return cs2Game?.minutes ?? 0;
+    // Return the playtime in minutes or -1 if CS2 is not found (hidden or not played)
+    return cs2Game?.minutes ?? -1;
   } catch (err) {
     console.error('Error getting CS2 game time:', err);
 

--- a/src/app/api/getCheaterProbability/utils/utils.ts
+++ b/src/app/api/getCheaterProbability/utils/utils.ts
@@ -1,0 +1,34 @@
+import { UserSummary } from 'steamapi';
+
+// Resolve account creation timestamp to milliseconds
+const resolveCreatedAtMs = (value: unknown): number | undefined => {
+  if (value instanceof Date) {
+    return value.getTime();
+  }
+
+  if (typeof value === 'number') {
+    return value * 1000;
+  }
+
+  if (value) {
+    return new Date(value as string).getTime();
+  }
+
+  return undefined;
+};
+
+export const clearStat = (stat: string) => {
+  const cleaned = stat.replace('ms', '').replace('%', '').trim();
+
+  return cleaned === '' ? undefined : cleaned;
+};
+
+export const getAccountAge = (userSummary: UserSummary) => {
+  const createdAtMs = resolveCreatedAtMs(userSummary.createdAt);
+  const accountAge =
+    createdAtMs && !Number.isNaN(createdAtMs)
+      ? Math.floor((Date.now() - createdAtMs) / (1000 * 60 * 60 * 24 * 365.25))
+      : undefined;
+
+  return accountAge;
+};

--- a/src/app/components/ReportBox/ReportBox.tsx
+++ b/src/app/components/ReportBox/ReportBox.tsx
@@ -14,14 +14,18 @@ interface ReportBoxProps {
 
 const borderColorClasses = {
   red: 'border-red-500',
+  orange: 'border-orange-500',
   yellow: 'border-yellow-500',
   green: 'border-green-500',
+  'dark-green': 'border-emerald-600',
 };
 
 const textColorClasses = {
   red: 'text-red-400',
+  orange: 'text-orange-400',
   yellow: 'text-yellow-400',
   green: 'text-green-400',
+  'dark-green': 'text-emerald-400',
 };
 
 function ReportBox({

--- a/src/app/templates/Home/templates/CheaterReport/useCheaterReport.ts
+++ b/src/app/templates/Home/templates/CheaterReport/useCheaterReport.ts
@@ -1,5 +1,4 @@
 import { CheaterDataType } from '@/@types/cheaterDataType';
-
 import { useTranslations } from 'next-intl';
 import { useEffect, useRef, useState } from 'react';
 import { ReportOutcomeKey, ReportOutcomes } from '@/@types/cheaterReportTypes';
@@ -35,23 +34,35 @@ const useCheaterReport = ({ isLoading, cheaterData }: useCheaterReportType) => {
       };
 
   const config = {
-    suspect: {
-      color: 'red',
-      icon: '🚩',
-      title: translator('suspectTitle'),
-      description: translator('suspectDescription'),
-    },
-    inconclusive: {
-      color: 'yellow',
-      icon: '⚠️',
-      title: translator('inconclusiveTitle'),
-      description: translator('inconclusiveDescription'),
+    veryTrusted: {
+      color: 'dark-green',
+      icon: '🛡️',
+      title: translator('veryTrustedTitle'),
+      description: translator('veryTrustedDescription'),
     },
     innocent: {
       color: 'green',
       icon: '✅',
       title: translator('innocentTitle'),
       description: translator('innocentDescription'),
+    },
+    inconclusive: {
+      color: 'yellow',
+      icon: '⚖️',
+      title: translator('inconclusiveTitle'),
+      description: translator('inconclusiveDescription'),
+    },
+    suspect: {
+      color: 'orange',
+      icon: '🔍',
+      title: translator('suspectTitle'),
+      description: translator('suspectDescription'),
+    },
+    highlySuspect: {
+      color: 'red',
+      icon: '🚩',
+      title: translator('highlySuspectTitle'),
+      description: translator('highlySuspectDescription'),
     },
   }[outcome as ReportOutcomeKey];
 

--- a/src/app/templates/Home/templates/CheaterReport/utils.ts
+++ b/src/app/templates/Home/templates/CheaterReport/utils.ts
@@ -1,6 +1,6 @@
 import { CheaterDataType } from '@/@types/cheaterDataType';
 import { ReportOutcomeKey, ReportOutcomes } from '@/@types/cheaterReportTypes';
-import clearStat from '@/app/api/getCheaterProbability/utils/clearCsStats';
+import { clearStat } from '@/app/api/getCheaterProbability/utils/utils';
 import { useTranslations } from 'next-intl';
 
 const analyzeCheaterData = (
@@ -40,7 +40,9 @@ const analyzeCheaterData = (
           typeof positiveMsg === 'function' ? positiveMsg() : positiveMsg,
         );
       }
-    } else if (conditionToBeSuspect ? conditionToBeSuspect(value) : negativeMsg) {
+    } else if (
+      conditionToBeSuspect ? conditionToBeSuspect(value) : negativeMsg
+    ) {
       // If conditionToBeSuspect is provided, it must be true to add negativeMsg.
       // If NOT provided, it defaults to the old behavior (adding negativeMsg if not innocent).
       if (negativeMsg) {

--- a/src/app/templates/Home/templates/CheaterReport/utils.ts
+++ b/src/app/templates/Home/templates/CheaterReport/utils.ts
@@ -17,14 +17,21 @@ const analyzeCheaterData = (
     positiveMsg,
     negativeMsg,
     conditionToBeInnocent,
+    conditionToBeSuspect,
   }: {
     value: number;
     positiveMsg?: string | (() => string);
     negativeMsg?: string | (() => string);
     conditionToBeInnocent: (v: number) => boolean;
+    conditionToBeSuspect?: (v: number) => boolean;
   }) => {
-    if (value === -1 || Number.isNaN(value) || value === undefined || value === null) {
-      return; // ignore invalid data
+    if (
+      value === -1 ||
+      Number.isNaN(value) ||
+      value === undefined ||
+      value === null
+    ) {
+      return; // ignore invalid or hidden data
     }
 
     if (conditionToBeInnocent(value)) {
@@ -33,10 +40,14 @@ const analyzeCheaterData = (
           typeof positiveMsg === 'function' ? positiveMsg() : positiveMsg,
         );
       }
-    } else if (negativeMsg) {
-      suspicionReasons.push(
-        typeof negativeMsg === 'function' ? negativeMsg() : negativeMsg,
-      );
+    } else if (conditionToBeSuspect ? conditionToBeSuspect(value) : negativeMsg) {
+      // If conditionToBeSuspect is provided, it must be true to add negativeMsg.
+      // If NOT provided, it defaults to the old behavior (adding negativeMsg if not innocent).
+      if (negativeMsg) {
+        suspicionReasons.push(
+          typeof negativeMsg === 'function' ? negativeMsg() : negativeMsg,
+        );
+      }
     }
   };
 
@@ -71,6 +82,45 @@ const analyzeCheaterData = (
     negativeMsg: translator('bannedFriends'),
     conditionToBeInnocent: (v) => v === 0,
   });
+
+  // Account Age
+  if (featureObject.accountAge !== undefined) {
+    addReason({
+      value: featureObject.accountAge,
+      positiveMsg: translator('oldAccount', { age: featureObject.accountAge }),
+      negativeMsg: translator('newAccount', { age: featureObject.accountAge }),
+      conditionToBeInnocent: (v) => v >= 7,
+      conditionToBeSuspect: (v) => v <= 2,
+    });
+  }
+
+  // Steam Level
+  addReason({
+    value: featureObject.userLevel,
+    positiveMsg: translator('highSteamLevel', {
+      level: featureObject.userLevel,
+    }),
+    negativeMsg: translator('lowSteamLevel', {
+      level: featureObject.userLevel,
+    }),
+    conditionToBeInnocent: (v) => v >= 10,
+    conditionToBeSuspect: (v) => v <= 3,
+  });
+
+  // Total Games Count
+  if (featureObject.totalGamesCount !== undefined) {
+    addReason({
+      value: featureObject.totalGamesCount,
+      positiveMsg: translator('manyGames', {
+        count: featureObject.totalGamesCount,
+      }),
+      negativeMsg: translator('fewGames', {
+        count: featureObject.totalGamesCount,
+      }),
+      conditionToBeInnocent: (v) => v >= 30,
+      conditionToBeSuspect: (v) => v <= 3,
+    });
+  }
 
   // Bad comments
   addReason({
@@ -130,15 +180,28 @@ const analyzeCheaterData = (
 
   // Final classification
   let outcome: ReportOutcomeKey;
-  if (cheaterProbability > 0.6) {
+  if (cheaterProbability > 0.8) {
+    outcome = ReportOutcomes.HIGHLY_SUSPECT;
+  } else if (cheaterProbability > 0.6) {
     outcome = ReportOutcomes.SUSPECT;
   } else if (cheaterProbability >= 0.4) {
     outcome = ReportOutcomes.INCONCLUSIVE;
-  } else {
+  } else if (cheaterProbability > 0.2) {
     outcome = ReportOutcomes.INNOCENT;
+  } else {
+    outcome = ReportOutcomes.VERY_TRUSTED;
   }
 
-  return { outcome, innocenceReasons, suspicionReasons };
+  const finalInnocenceReasons =
+    outcome === ReportOutcomes.HIGHLY_SUSPECT ? [] : innocenceReasons;
+  const finalSuspicionReasons =
+    outcome === ReportOutcomes.VERY_TRUSTED ? [] : suspicionReasons;
+
+  return {
+    outcome,
+    innocenceReasons: finalInnocenceReasons,
+    suspicionReasons: finalSuspicionReasons,
+  };
 };
 
 export default analyzeCheaterData;


### PR DESCRIPTION
This PR enhances the cheater detection report by introducing more granular classification levels and additional account-based signals.

### Key changes:
* Added new report outcomes: `VERY_TRUSTED` and `HIGHLY_SUSPECT`
* Refined probability thresholds for more accurate classification
* Introduced new signals:
    * Account age
    * Total games owned
    * Steam level (better categorized)
* Improved reasoning system:
    * Supports explicit "suspect" conditions (not just non-innocent)
    * Ignores hidden/invalid data more robustly
* Updated UI:
    * New color tiers (dark green, orange)
    * New icons and messaging per outcome
* Expanded i18n (EN/PT) with new labels and descriptions
* Refactored utilities:
    * Centralized clearStat
* Added getAccountAge
* Minor fix: treat missing CS2 playtime as -1 instead of 0